### PR TITLE
feat: 部署到权限中心后，下载的项目源码才会写入权限中心相关的配置；当应用未进行部署直接下载源码时，不会生成权限中心相关的配置即不会鉴权

### DIFF
--- a/lib/server/model/project-code.js
+++ b/lib/server/model/project-code.js
@@ -551,18 +551,21 @@ const projectCode = {
                     }
                 )
 
-                // 应用权限模型，权限中心的配置
-                await this.generateFileByReplace(
-                    path.join(targetPath, 'lib/server/conf/iam.js'),
-                    path.join(targetPath, 'lib/server/conf/iam.js'),
-                    (content) => {
-                        return content.replace(/\$\{iamSaasHost\}/g, IAM_SAAS_HOST)
-                            .replace(/\$\{iamHost\}/g, IAM_HOST)
-                            .replace(/\$\{iamAppId\}/g, IAM_APP_ID)
-                            .replace(/\$\{iamAppSecret\}/g, IAM_APP_SECRET)
-                            .replace(/\$\{iamSystemId\}/g, iamAppPerm.systemId)
-                    }
-                )
+                // 部署到权限中心后，下载的项目源码才会写入权限中心相关的配置
+                if (iamAppPerm.deployed === 1) {
+                    // 应用权限模型，权限中心的配置
+                    await this.generateFileByReplace(
+                        path.join(targetPath, 'lib/server/conf/iam.js'),
+                        path.join(targetPath, 'lib/server/conf/iam.js'),
+                        (content) => {
+                            return content.replace(/\$\{iamSaasHost\}/g, IAM_SAAS_HOST)
+                                .replace(/\$\{iamHost\}/g, IAM_HOST)
+                                .replace(/\$\{iamAppId\}/g, IAM_APP_ID)
+                                .replace(/\$\{iamAppSecret\}/g, IAM_APP_SECRET)
+                                .replace(/\$\{iamSystemId\}/g, iamAppPerm.systemId)
+                        }
+                    )
+                }
 
                 resolve('success')
             } catch (err) {

--- a/lib/server/project-template/project-init-code/lib/server/controller/iam.js
+++ b/lib/server/project-template/project-init-code/lib/server/controller/iam.js
@@ -48,6 +48,13 @@ export default class IamController {
             return
         }
 
+        // 这几个配置中有一个为空，就认为是权限中心配置不正确，不鉴权
+        // 当应用未进行部署直接下载源码时，生成项目源码时，这四个配置不会设置
+        if (!IAM_HOST || !IAM_APP_ID || !IAM_APP_SECRET || !IAM_SYSTEM_ID) {
+            ctx.send({ code: 0, message: 'OK', data: { allowed: true } })
+            return
+        }
+
         const { action = '', resourceId = '', resourceName = '', needAuth = false } = ctx.request.body
 
         // lesscode 平台没有选择的资源实例就不需要权限校验


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- feat: 部署到权限中心后，下载的项目源码才会写入权限中心相关的配置；当应用未进行部署直接下载源码时，不会生成权限中心相关的配置即不会鉴权