### PR TITLE
feat: 部署到权限中心后，下载的项目源码才会写入权限中心相关的配置；当应用未进行部署直接下载源码时，不会生成权限中心相关的配置即不会鉴权

### DIFF
--- a/lib/server/model/project-code.js
+++ b/lib/server/model/project-code.js
@@ -552,20 +552,18 @@ const projectCode = {
                 )
 
                 // 部署到权限中心后，下载的项目源码才会写入权限中心相关的配置
-                if (iamAppPerm.deployed === 1) {
-                    // 应用权限模型，权限中心的配置
-                    await this.generateFileByReplace(
-                        path.join(targetPath, 'lib/server/conf/iam.js'),
-                        path.join(targetPath, 'lib/server/conf/iam.js'),
-                        (content) => {
-                            return content.replace(/\$\{iamSaasHost\}/g, IAM_SAAS_HOST)
-                                .replace(/\$\{iamHost\}/g, IAM_HOST)
-                                .replace(/\$\{iamAppId\}/g, IAM_APP_ID)
-                                .replace(/\$\{iamAppSecret\}/g, IAM_APP_SECRET)
-                                .replace(/\$\{iamSystemId\}/g, iamAppPerm.systemId)
-                        }
-                    )
-                }
+                // 应用权限模型，权限中心的配置
+                await this.generateFileByReplace(
+                    path.join(targetPath, 'lib/server/conf/iam.js'),
+                    path.join(targetPath, 'lib/server/conf/iam.js'),
+                    (content) => {
+                        return content.replace(/\$\{iamSaasHost\}/g, iamAppPerm.deployed === 1 ? IAM_SAAS_HOST : '')
+                            .replace(/\$\{iamHost\}/g, iamAppPerm.deployed === 1 ? IAM_HOST : '')
+                            .replace(/\$\{iamAppId\}/g, iamAppPerm.deployed === 1 ? IAM_APP_ID : '')
+                            .replace(/\$\{iamAppSecret\}/g, iamAppPerm.deployed === 1 ? IAM_APP_SECRET : '')
+                            .replace(/\$\{iamSystemId\}/g, iamAppPerm.deployed === 1 ? iamAppPerm.systemId : '')
+                    }
+                )
 
                 resolve('success')
             } catch (err) {


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- feat: 部署到权限中心后，下载的项目源码才会写入权限中心相关的配置；当应用未进行部署直接下载源码时，不会生成权限中心相关的配置即不会鉴权