### PR TITLE
feat: 应用权限模型，画布组件绑定权限操作体验问题修复

### DIFF
--- a/lib/client/src/store/modules/iam.js
+++ b/lib/client/src/store/modules/iam.js
@@ -77,6 +77,13 @@ export default {
             })
         },
 
+        checkActionId ({ commit }, params) {
+            return http.post('/iam/check-action', params.data).then(response => {
+                const data = response.data || ''
+                return data
+            })
+        },
+
         deleteIamAppPermAction ({ commit }, params) {
             const { projectId, actionId } = params
             return http.delete(`/iam/app-perm-model-action?projectId=${projectId}&actionId=${actionId}`).then(

--- a/lib/client/src/views/project/app-perm-model/app-perm-model-sideslider.vue
+++ b/lib/client/src/views/project/app-perm-model/app-perm-model-sideslider.vue
@@ -19,7 +19,7 @@
                         <bk-input v-model="formData.actionNameEn" placeholder="请输入操作名称英文：如 View Page"></bk-input>
                     </bk-form-item>
                     <bk-form-item label="操作类型" property="actionType">
-                        <bk-select v-model="formData.actionType" @change="actionTypeChange">
+                        <bk-select v-model="formData.actionType">
                             <bk-option v-for="item in actionTypeList" :key="item.id"
                                 :id="item.id" :name="item.name">
                             </bk-option>
@@ -33,7 +33,7 @@
                             </bk-radio-group>
                         </bk-form-item>
                         <bk-form-item label="关联资源" property="actionRelatedResourceId" v-if="formData.hasRelated">
-                            <bk-select v-model="formData.actionRelatedResourceId" @change="relatedResourceChange" placeholder="请选择资源" multiple>
+                            <bk-select v-model="formData.actionRelatedResourceId" placeholder="请选择资源" multiple>
                                 <bk-option v-for="item in relatedResourceList" :key="item.id"
                                     :id="item.id" :name="item.name">
                                 </bk-option>
@@ -95,6 +95,11 @@
                             required: true,
                             message: '请填写操作 ID',
                             trigger: 'blur'
+                        },
+                        {
+                            message: '操作 ID 在应用内唯一',
+                            trigger: 'blur',
+                            validator: this.checkActionId
                         }
                     ],
                     actionName: [
@@ -176,6 +181,21 @@
                 })
             },
 
+            async checkActionId (val) {
+                try {
+                    const res = await this.$store.dispatch('iam/checkActionId', {
+                        data: {
+                            projectId: this.projectId,
+                            actionId: val
+                        }
+                    })
+                    return !res.exist
+                } catch (e) {
+                    console.error(e)
+                    return false
+                }
+            },
+
             async getRelatedResourceList () {
                 this.isLoading = true
                 try {
@@ -189,14 +209,6 @@
                 } finally {
                     this.isLoading = false
                 }
-            },
-
-            actionTypeChange () {
-
-            },
-
-            relatedResourceChange () {
-
             },
 
             validate () {

--- a/lib/server/controller/iam.js
+++ b/lib/server/controller/iam.js
@@ -126,6 +126,26 @@ const iamController = {
         }
     },
 
+    async checkIamAppPermActionId (ctx) {
+        const { projectId, actionId } = ctx.request.body
+        try {
+            const iamAppPermActionList = await iamAppPermModel.getIamAppPermActions(projectId) || []
+            const existAction = iamAppPermActionList.find(item => item.actionId === actionId)
+
+            ctx.send({
+                code: 0,
+                message: 'OK',
+                data: {
+                    exist: !!existAction
+                }
+            })
+        } catch (err) {
+            ctx.throwError({
+                message: err.message
+            })
+        }
+    },
+
     async iamAppPermRegistry (ctx, iamAppPerm) {
         // system
         const systemRes = await sendReq(
@@ -763,7 +783,7 @@ const iamController = {
      */
     async check (ctx) {
         if (!global.IAM_ENABLE) {
-            ctx.send({ code: 0, message: 'OK', data: { allowed: true } })
+            ctx.send({ code: 0, message: 'OK', data: { allowed: true, pass: true } })
             return
         }
 

--- a/lib/server/model/page-code.js
+++ b/lib/server/model/page-code.js
@@ -359,10 +359,12 @@ class PageCode {
             //     @keypress="yyy">
             //     xxx
             // </auth-button>
-            if (item.renderPerms && item.renderPerms.length) {
-                if (this.appPermComponents[item.type]) {
-                    item.type = this.appPermComponents[item.type]
-                    itemProps += ` auth="${item.renderPerms.map(perm => perm.actionId).join(',')}"`
+            if (global.IAM_ENABLE) {
+                if (item.renderPerms && item.renderPerms.length) {
+                    if (this.appPermComponents[item.type]) {
+                        item.type = this.appPermComponents[item.type]
+                        itemProps += ` auth="${item.renderPerms.map(perm => perm.actionId).join(',')}"`
+                    }
                 }
             }
             let componentCode = ''

--- a/lib/server/project-template/project-init-code/lib/server/controller/iam.js
+++ b/lib/server/project-template/project-init-code/lib/server/controller/iam.js
@@ -44,21 +44,21 @@ export default class IamController {
         @Ctx() ctx
     ) {
         if (!global.IAM_ENABLE) {
-            ctx.send({ code: 0, message: 'OK', data: { allowed: true } })
+            ctx.send({ code: 0, message: 'OK', data: { allowed: true, pass: true } })
             return
         }
 
         // 这几个配置中有一个为空，就认为是权限中心配置不正确，不鉴权
         // 当应用未进行部署直接下载源码时，生成项目源码时，这四个配置不会设置
         if (!IAM_HOST || !IAM_APP_ID || !IAM_APP_SECRET || !IAM_SYSTEM_ID) {
-            ctx.send({ code: 0, message: 'OK', data: { allowed: true } })
+            ctx.send({ code: 0, message: 'OK', data: { allowed: true, pass: true } })
             return
         }
 
         const { action = '', resourceId = '', resourceName = '', needAuth = false } = ctx.request.body
 
         if (!needAuth) {
-            ctx.send({ code: 0, message: 'OK', data: { allowed: true } })
+            ctx.send({ code: 0, message: 'OK', data: { allowed: true, pass: true } })
             return
         }
 
@@ -156,14 +156,14 @@ export default class IamController {
         @Ctx() ctx
     ) {
         if (!global.IAM_ENABLE) {
-            ctx.send({ code: 0, message: 'OK', data: { allowed: true } })
+            ctx.send({ code: 0, message: 'OK', data: { allowed: true, pass: true } })
             return
         }
 
         // 这几个配置中有一个为空，就认为是权限中心配置不正确，不鉴权
         // 当应用未进行部署直接下载源码时，生成项目源码时，这四个配置不会设置
         if (!IAM_HOST || !IAM_APP_ID || !IAM_APP_SECRET || !IAM_SYSTEM_ID) {
-            ctx.send({ code: 0, message: 'OK', data: { allowed: true } })
+            ctx.send({ code: 0, message: 'OK', data: { allowed: true, pass: true } })
             return
         }
 

--- a/lib/server/router/iam.js
+++ b/lib/server/router/iam.js
@@ -17,14 +17,15 @@ const Router = require('koa-router')
 
 const {
     fetchResource, check, myProject, checkNoResources, fetchAuthSubject,
-    fetchIamAppPerm, fetchIamAppPermAction, updateIamAppPermAction, addIamAppPermAction, deleteIamAppPermAction, fetchResourceAppPerm
+    fetchIamAppPerm, fetchIamAppPermAction, fetchResourceAppPerm, checkIamAppPermActionId,
+    updateIamAppPermAction, addIamAppPermAction, deleteIamAppPermAction
 } = require('../controller/iam')
 
 const router = new Router({
     prefix: '/api/iam'
 })
 
-router.use(['/auth-subject', '/app-perm-model', '/app-perm-model-action'], async (ctx, next) => {
+router.use(['/auth-subject', '/app-perm-model', '/app-perm-model-action', '/check-action'], async (ctx, next) => {
     const id = ['POST', 'PUT'].includes(ctx.request.method)
         ? (ctx.request.body.id || ctx.request.body.projectId)
         : (ctx.request.query.id || ctx.request.query.projectId)
@@ -69,5 +70,6 @@ router.get('/app-perm-model-action', fetchIamAppPermAction)
 router.put('/app-perm-model-action', updateIamAppPermAction)
 router.post('/app-perm-model-action', addIamAppPermAction)
 router.delete('/app-perm-model-action', deleteIamAppPermAction)
+router.post('/check-action', checkIamAppPermActionId)
 
 module.exports = router


### PR DESCRIPTION
## 变更点(Changes)

1. 新增操作时 actionId 项目内重名校验
2. 修复已有权限按钮点击后还是弹出申请权限弹框的问题
3. 预览时不渲染绑定权限操作的组件，还是渲染原组件（通过 IAM_ENABLE 判断）
