### PR TITLE
fix: 自由布局无法选中以及自由布局内部组件游离在自由布局外的问题

### DIFF
--- a/lib/client/src/components/render/pc/index.vue
+++ b/lib/client/src/components/render/pc/index.vue
@@ -120,7 +120,7 @@
                             'padding: 2px 5px; background: #42c02e; color: #fff; border-radius: 0 3px 3px 0; font-weight: bold;',
                             event)
             }
-            
+
             const activeLogCallback = event => {
                 console.log('\n')
                 console.log(`%c>> ${new Date().toString().slice(0, 25)}`,
@@ -185,7 +185,7 @@
         mounted () {
             this.componentData.mounted(this.$refs.root)
             LC._mounted()
-            
+
             const mousedownCallback = () => {
                 setMousedown(true)
             }
@@ -195,11 +195,11 @@
             const resetCallback = () => {
                 LC.clearMenu()
             }
-            
+
             document.body.addEventListener('mousedown', mousedownCallback)
             document.body.addEventListener('mouseup', mouseupCallback)
             document.body.addEventListener('click', resetCallback)
-            
+
             this.$once('hook:beforeDestroy', () => {
                 document.body.removeEventListener('mousedown', mousedownCallback)
                 document.body.removeEventListener('mouseup', mouseupCallback)
@@ -229,7 +229,7 @@
                     top: componentTop,
                     left: componentLeft
                 } = $childEl.getBoundingClientRect()
-                
+
                 const styles = {}
                 if (componentTop > boxTop + 3) {
                     styles['marginTop'] = '8px'

--- a/lib/client/src/components/render/pc/resolve-component.vue
+++ b/lib/client/src/components/render/pc/resolve-component.vue
@@ -386,7 +386,7 @@
                     return
                 }
                 const componentDataStyle = this.componentData.style
-                
+
                 // 优先使用自定义配置的 line-height
                 if (_.has(componentDataStyle, 'line-height')
                     && componentDataStyle['line-height'] !== '') {

--- a/lib/client/src/components/render/pc/tools/hooks/use-component-active.js
+++ b/lib/client/src/components/render/pc/tools/hooks/use-component-active.js
@@ -21,7 +21,7 @@ export default function (callbak) {
         callbak(event.target)
         hoverResizeObserver.observe($drawTarget)
     }
-    
+
     const updateCallbak = _.throttle(() => {
         if (!componentData.value.componentId) {
             return
@@ -61,7 +61,7 @@ export default function (callbak) {
     LC.addEventListener('reset', resetCallback)
     LC.addEventListener('componentDragStart', componentDragStartCallbak)
     LC.addEventListener('componentDragEnd', componentDragEndCallbak)
-    
+
     const hoverResizeObserver = new ResizeObserver(updateCallbak)
     onMounted(() => {
         $drawTarget = document.body.querySelector('#drawTarget')

--- a/lib/client/src/components/render/pc/tools/lesscode-resize/hooks/use-resize.js
+++ b/lib/client/src/components/render/pc/tools/lesscode-resize/hooks/use-resize.js
@@ -27,7 +27,7 @@ export default function () {
     let startScreenY = 0
     let moveStartWidth = 0
     let moveStartHeight = 0
-            
+
     const state = reactive({
         tipStyles: hideStyles,
         size: hideStyles
@@ -67,7 +67,7 @@ export default function () {
             width: newWidth || width,
             height: newHeight || height
         }
-        
+
         nextTick(() => {
             const {
                 top: containerTop,
@@ -154,7 +154,7 @@ export default function () {
         handleResizeHeight(event)
         calcPosition(event)
     }
-    
+
     /**
      * @desc mousemove 事件，动态更新容器宽度
      * @param {Object} event
@@ -166,6 +166,43 @@ export default function () {
         dragLine.check(proxy.activeComponentData.$elm, '[role="component-root"]')
         calcPosition(event)
     }, 30)
+
+    const checkFreeLayoutBoundary = () => {
+        if (proxy.activeComponentData.type !== 'free-layout') {
+            return
+        }
+
+        const {
+            width: activeNodeWidth,
+            height: activeNodeHeight,
+            top: activeNodeTop,
+            left: activeNodeLeft
+        } = proxy.activeComponentData.$elm.getBoundingClientRect()
+        const children = proxy.activeComponentData.children
+        let maxHeightAndTop = Number.MIN_SAFE_INTEGER
+        let maxWidthAndLeft = Number.MIN_SAFE_INTEGER
+        children.forEach(node => {
+            const { top, height, left, width } = node.$elm.getBoundingClientRect()
+            if (maxHeightAndTop <= top + height) {
+                maxHeightAndTop = top + height
+            }
+            if (maxWidthAndLeft <= left + width) {
+                maxWidthAndLeft = left + width
+            }
+        })
+        maxHeightAndTop = Math.floor(maxHeightAndTop)
+        maxWidthAndLeft = Math.floor(maxWidthAndLeft)
+
+        const freeLayoutHeightBoundary = Math.floor(activeNodeTop + activeNodeHeight)
+        if (freeLayoutHeightBoundary < maxHeightAndTop) {
+            proxy.activeComponentData.setStyle('height', `${maxHeightAndTop - activeNodeTop + 1}px`)
+        }
+
+        const freeLayoutWidthBoundary = Math.floor(activeNodeLeft + activeNodeWidth)
+        if (freeLayoutWidthBoundary < maxWidthAndLeft) {
+            proxy.activeComponentData.setStyle('width', `${maxWidthAndLeft - activeNodeLeft + 1}px`)
+        }
+    }
 
     /**
      * @desc 放开鼠标取消拖动状态
@@ -181,6 +218,8 @@ export default function () {
             dragLine.uncheck()
             dragLine = null
         }
+
+        checkFreeLayoutBoundary()
     }
 
     onMounted(() => {

--- a/lib/client/src/components/render/pc/tools/lesscode-resize/index.vue
+++ b/lib/client/src/components/render/pc/tools/lesscode-resize/index.vue
@@ -120,7 +120,7 @@
                         }
                     }
                 })
-                
+
                 const {
                     top: containerTop,
                     left: containerLeft,
@@ -135,7 +135,7 @@
                 } = componentData.$elm.getBoundingClientRect()
 
                 const dotBaseStyle = Object.assign({}, baseStyles)
-                
+
                 if (resizeWidthEnabel) {
                     state.dotWidthStyles = Object.assign({}, dotBaseStyle, {
                         top: `${top - containerTop + height / 2 - halfDotSize}px`,
@@ -222,7 +222,7 @@
         justify-content: center;
         height: 15px;
         width: 15px;
-        
+
         &:after{
             content: '';
             position: absolute;

--- a/lib/client/src/components/render/pc/widget/free-layout.vue
+++ b/lib/client/src/components/render/pc/widget/free-layout.vue
@@ -86,8 +86,9 @@
                         container: this.$el
                     })
                 }
+
                 const dragEle = this.$refs[childNode.componentId][0].$el
-                
+
                 this.drag = new Drag(dragEle, {
                     container: dragEle.parentNode
                 })
@@ -97,6 +98,9 @@
                 let isMoveing = false
 
                 this.drag.on('move', () => {
+                    // fix: 自由布局选中时，直接按住其中的组件然后拖动，之后再松开鼠标，自由布局不会选中的问题
+                    LC.getActiveNode() && LC.getActiveNode().activeClear()
+
                     if (!isMoveing) {
                         LC.triggerEventListener('componentMouserleave')
                         childNode.activeClear()
@@ -107,7 +111,7 @@
                     this.dragLine.uncheck()
                     const left = parseFloat(this.drag.$elem.style.left)
                     const top = parseFloat(this.drag.$elem.style.top)
-                    
+
                     childNode.setStyle({
                         left: left + 'px',
                         top: top + 'px'
@@ -139,7 +143,7 @@
                 const $elem = this.$refs[childNode.componentId][0].$el
 
                 this.doDrag(childNode)
-                
+
                 // setTimeout 保证 drag add 事件已经处理完毕
                 setTimeout(() => {
                     const freeLayoutContainer = this.$refs[this.componentData.componentId]
@@ -150,7 +154,7 @@
                         width: componentWidth,
                         height: componentHeight
                     } = $elem
-                    
+
                     const {
                         top: containerTop,
                         right: containerRight,


### PR DESCRIPTION
## 变更点(Changes)

- fix: 自由布局选中时，直接按住其中的组件然后拖动，之后再松开鼠标，自由布局不会选中的问题；
- fix: 修复创建了自由布局后, 可以降低高度, 导致此前拖动的组件游离在自由布局区外了. 继续拖动时才会跳回框内 的问题

## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)
