### PR TITLE
fix: 修复移动端vant-input组件值绑定空变量渲染出错的问题

### DIFF
--- a/lib/shared/page-code/template/page/prop.js
+++ b/lib/shared/page-code/template/page/prop.js
@@ -201,7 +201,8 @@ function getPropsStr (code, type, compId, props, dirProps, slots) {
             const valueType = typeof props['value'].code
             if (valueType !== 'array' && valueType !== 'object') {
                 let vModelValue = props['value'].code.toString()
-                if (valueType === 'string') vModelValue = `'${props['value'].code}'`
+                // 如果value属性的格式是variable，则其v-model需要绑定该变量；否则，绑定默认生成的变量
+                if (valueType === 'string') vModelValue = props['value'].format === 'variable' ? `this.${props['value'].code}` : `'${props['value'].code}'`
                 code.dataTemplate(modelComId, vModelValue)
             }
             propsStr += `v-model="${modelComId}"`


### PR DESCRIPTION
<!--
请保证PR标题明确清晰, 易于理解
Keep PR title verbose enough

相关issue可以是 #编号 或者贴 issue链接
`Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


## 变更点(Changes)

- xxxx

## 相关issues (Which issues this PR fixes)

- Fixes #

## 备注(Special notes)
